### PR TITLE
Add support for both Python2.6+ and Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple example [Flask](http://flask.pocoo.org/) app, showing how to use [Rollb
 
 ## How to run
 
-This example requires Python 2.6+, pip, and virtualenv.
+This example requires Python 3 (or 2.6+), pip, and virtualenv.
 
 ```
 virtualenv .venv

--- a/hello.py
+++ b/hello.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from flask import Flask
 app = Flask(__name__)
 
@@ -45,7 +47,7 @@ app.request_class = CustomRequest
 
 @app.route('/')
 def hello():
-    print "in hello"
+    print("in hello")
     x = None
     x[5]
     return "Hello World!"


### PR DESCRIPTION
The current version of the example doesn't work under Python3. This PR adds the support for it.

This is related to [ch79857]