### PR TITLE
Remove deprecated before_first_request

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -12,9 +12,7 @@ import rollbar.contrib.flask
 from flask import got_request_exception
 
 
-@app.before_first_request
-def init_rollbar():
-    """init rollbar module"""
+with app.app_context():
     rollbar.init(
         # access token for the demo app: https://rollbar.com/demo
         'fc316ac1f7404dc28af26d5baed1416c',


### PR DESCRIPTION
## Description of the change

Flask v2.3.0 removes its deprecated `before_first_request` decorator (see [changelog](https://flask.palletsprojects.com/en/2.3.x/changes/)).  This updates the flask example to replace the decorator with an equivalent example.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

 - https://github.com/rollbar/pyrollbar/pull/428

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
